### PR TITLE
Fix tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,27 +19,27 @@ and an optional foot (`tfoot`).
 It defines four additional table roles: `head`, `body`, `foot` and `caption`.
 The first three are "section roles".
 
-`prosemirror-tables` defines a custom
-[TableView](https://github.com/ProseMirror/prosemirror-tables/blob/master/src/tableview.ts)
-that creates the `colgroup` DOM element and manages the `style` attribute
-of the `table` element.
-
-`prosemirror-tables-sections` does not need a custom 
-[EditorView](https://prosemirror.net/docs/ref/#view.EditorView).
-`colgroup` and table's `style` are set through 
-[Decorations](https://prosemirror.net/docs/ref/#view.Decorations).
-
 The top-level directory contains a `demo.js` and `index.html`, which
 can be built with `npm run build_demo` or `yarn build_demo`
 to show a simple demo of how the module can be used.
 
 ## Version
 
-This is version 0.5.0, and it fixes the "copy and paste" of tables.
+This is version 0.6.0, and it goes back to the implementation
+of `columnresizing.ts` and `tableview.ts` you find in the original
+[prosemirror-tables](https://github.com/ProseMirror/prosemirror-tables),
+adapted to table sections.
 
-Until version 0.4.9 the pasted tables (or parts of tables)
-did not keep their column widths.
-Now you should get an exact copy.
+BTW, thanks to the people maintaining the original project,
+in particular for the translation into Typescript, that let
+me go back to the original implementation of column resizing.
+
+## Known issues
+
+When you copy a portion of a table and you paste, you'll get a table
+with all the cells you copied, but they will be all in a table foot.
+
+Anyway, you can correct it into a table body with the `makeBody` command.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,16 @@ of the `table` element.
 [Decorations](https://prosemirror.net/docs/ref/#view.Decorations).
 
 The top-level directory contains a `demo.js` and `index.html`, which
-can be built with `yarn build_demo` to show a simple demo of how the
-module can be used.
+can be built with `npm run build_demo` or `yarn build_demo`
+to show a simple demo of how the module can be used.
+
+## Version
+
+This is version 0.5.0, and it fixes the "copy and paste" of tables.
+
+Until version 0.4.9 the pasted tables (or parts of tables)
+did not keep their column widths.
+Now you should get an exact copy.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,38 @@ to show a simple demo of how the module can be used.
 
 ## Version
 
-This is version 0.6.0, and it goes back to the implementation
+This is version 0.6.1.
+
+It adds two commands:
+
+- `setComputedStyleColumnWidths`, that sets the cells widths of a table
+  to the actual values you may have set with CSS.
+  It uses [window.getComputedStyle](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle)
+  to retrieve those widths.
+  If there's a column selection, it sets the widths of the selected columns' cells only,
+  otherwise it sets all the cells widths of the (inner) table in the selection.
+
+- `setRelativeColumnWidths(widths: number[], minwidth?: number)`,
+  that returns a [Command](https://prosemirror.net/docs/ref/#state.Command)
+  to set the relative widths of the (inner) table in the selection.
+  The relative widths must be in the range 0..1.
+  
+  The table width is the one obtained with [window.getComputedStyle](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle).
+  The new cells will get a _col width_ = _rel width_ * _table width_.
+  
+  If you specify `minwidth`, the columns will not be narrower than that.
+
+  If `widths.length` is greater than the number of columns, 
+  the exceeding widths will be ignored.
+
+  If `widths.length` is lesser than the number of columns,
+  only the first column widths will be set.
+
+The code of this version has been checked with the current version of
+[prosemirror-tables](https://github.com/ProseMirror/prosemirror-tables)
+(resulting in a bug being fixed).
+
+Since version 0.6.0 the code goes back to the implementation
 of `columnresizing.ts` and `tableview.ts` you find in the original
 [prosemirror-tables](https://github.com/ProseMirror/prosemirror-tables),
 adapted to table sections.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ to show a simple demo of how the module can be used.
 
 ## Version
 
-This is version 0.6.1.
+This is version 0.6.3.
 
-It adds two commands:
+It fixes a nasty bug in the detection of table problems (e.g. missing or colliding cells),
+that are then fixed by `fixTables`.
+
+Since version 0.6.1, two commands have been added:
 
 - `setComputedStyleColumnWidths`, that sets the cells widths of a table
   to the actual values you may have set with CSS.

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -38,6 +38,7 @@ import {
   goToNextCell,
   deleteTable,
   setComputedStyleColumnWidths,
+  setRelativeColumnWidths,
 } from '../src';
 import { tableEditing, columnResizing, tableNodes, fixTables } from '../src';
 
@@ -69,6 +70,7 @@ function item(label: string, cmd: (state: EditorState) => boolean) {
 }
 const tableMenu = [
   item('Set column widths with getComputedStyle', setComputedStyleColumnWidths),
+  item('Set column widths to 20%, 60%, 20%', setRelativeColumnWidths([.2, .6, .2])),
   item('Add table caption', addCaption),
   item('Delete table caption', deleteCaption),
   item('Add table head', addTableHead),

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -37,6 +37,7 @@ import {
   toggleHeaderCell,
   goToNextCell,
   deleteTable,
+  setComputedStyleColumnWidths,
 } from '../src';
 import { tableEditing, columnResizing, tableNodes, fixTables } from '../src';
 
@@ -67,6 +68,7 @@ function item(label: string, cmd: (state: EditorState) => boolean) {
   return new MenuItem({ label, select: cmd, run: cmd });
 }
 const tableMenu = [
+  item('Set column widths with getComputedStyle', setComputedStyleColumnWidths),
   item('Add table caption', addCaption),
   item('Delete table caption', deleteCaption),
   item('Add table head', addTableHead),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massifrg/prosemirror-tables-sections",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": "massifrg <massifrg@gmail.com>",
   "description": "prosemirror-tables derived component to support tables with caption/thead/tbody/tfoot",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massifrg/prosemirror-tables-sections",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "massifrg <massifrg@gmail.com>",
   "description": "prosemirror-tables derived component to support tables with caption/thead/tbody/tfoot",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massifrg/prosemirror-tables-sections",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "massifrg <massifrg@gmail.com>",
   "description": "prosemirror-tables derived component to support tables with caption/thead/tbody/tfoot",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massifrg/prosemirror-tables-sections",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "author": "massifrg <massifrg@gmail.com>",
   "description": "prosemirror-tables derived component to support tables with caption/thead/tbody/tfoot",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@massifrg/prosemirror-tables-sections",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": "massifrg <massifrg@gmail.com>",
   "description": "prosemirror-tables derived component to support tables with caption/thead/tbody/tfoot",
   "type": "module",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -41,8 +41,6 @@ import {
 } from './util';
 import {
   columnResizingPluginKey,
-  getCellMinWidth,
-  getTableWidths,
 } from './columnresizing';
 
 /**
@@ -697,10 +695,6 @@ function makeSection(
       tableStart + cellsPositions[cellsPositions.length - 1],
     );
     tr.setSelection(new CellSelection($anchorCell, $headCell));
-    tr.setMeta(
-      columnResizingPluginKey,
-      getTableWidths(table, tableStart, getCellMinWidth(state)),
-    );
     dispatch(tr);
   }
   return true;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1305,7 +1305,7 @@ function updateColumnWidthsTransaction(
   for (let r = 0; r < map.height; r++) {
     for (let c = left; c < right; c++) {
       const pos = map.positionAt(r, c, table) + tableStart;
-      if (updated.includes(pos)) continue;
+      if (updated.indexOf(pos) >= 0) continue;
       else updated.push(pos);
       const cell = doc.nodeAt(pos);
       if (cell) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -336,7 +336,7 @@ export function removeRow(
         rowspan: attrs.rowspan - 1,
       });
       col += attrs.colspan - 1;
-    } else if (row < map.width && pos == map.map[index + map.width]) {
+    } else if (row < map.height && pos == map.map[index + map.width]) {
       // Else, if it continues in the row below, it has to be moved down
       const cell = table.nodeAt(pos)!;
       const attrs = cell.attrs as CellAttrs;

--- a/src/fixtables.ts
+++ b/src/fixtables.ts
@@ -4,12 +4,7 @@
 // reported by `TableMap`.
 
 import { Node } from 'prosemirror-model';
-import {
-  EditorState,
-  NodeSelection,
-  PluginKey,
-  Transaction,
-} from 'prosemirror-state';
+import { EditorState, PluginKey, Transaction } from 'prosemirror-state';
 import { tableNodeTypes, TableRole } from './schema';
 import { TableMap } from './tablemap';
 import { CellAttrs, getRow, removeColSpan } from './util';
@@ -144,14 +139,10 @@ export function fixTable(
       const nodes: Node[] = [];
       for (let j = 0; j < add; j++) {
         const node = tableNodeTypes(state.schema)[role].createAndFill();
-
         if (node) nodes.push(node);
       }
       const side = (i == 0 || first == i - 1) && last == i ? pos + 1 : end - 1;
-      // console.log(
-      //   `i(row)=${i} pos=${pos}, end=${end}, cells to add=${add}, side=${side}`,
-      // );
-      tr.insert(tr.mapping.map(side + 1), nodes);
+      tr.insert(tr.mapping.map(tablePos + side + 1), nodes);
     }
   }
   return tr.setMeta(fixTablesKey, { fixTables: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,6 @@ export {
 export type {
   ColumnResizingOptions,
   Dragging,
-  SetColWidthsAction,
-  SetTableWidthAction,
 } from './columnresizing';
 export * from './commands';
 export {

--- a/src/input.ts
+++ b/src/input.ts
@@ -107,11 +107,12 @@ function tabulation(dir: Direction): Command {
       nextCellPos = map[i];
     }
     if (nextCellPos) {
-      const cell = table.nodeAt(nextCellPos);
-      if (!cell) return false;
+      const nextCellInnerPos = nextCellPos + 1;
+      const cellFirstChild = table.nodeAt(nextCellInnerPos);
+      if (!cellFirstChild) return false;
       if (dispatch) {
-        const from = tableStart + nextCellPos;
-        const to = from + cell.nodeSize - 1;
+        const from = tableStart + nextCellInnerPos;
+        const to = from + cellFirstChild.nodeSize - 1;
         dispatch(
           state.tr.setSelection(TextSelection.create(state.doc, from, to)),
         );

--- a/src/tablemap.ts
+++ b/src/tablemap.ts
@@ -464,7 +464,6 @@ function findBadColWidths(
     const pos = map.map[i];
     if (seen[pos]) continue;
     seen[pos] = true;
-    // const node = section.nodeAt(pos - 1);
     const node = table.nodeAt(pos);
     if (!node) {
       throw new RangeError(`No cell with offset ${pos} found`);
@@ -481,13 +480,12 @@ function findBadColWidths(
       )
         (updated || (updated = freshColWidth(attrs)))[j] = colWidth;
     }
-    if (updated) {
+    if (updated)
       map.problems.unshift({
         type: 'colwidth mismatch',
         pos,
         colwidth: updated,
       });
-    }
   }
 }
 

--- a/src/tablemap.ts
+++ b/src/tablemap.ts
@@ -140,7 +140,7 @@ export class TableMap {
       if (curPos != pos) continue;
 
       const left = i % this.width;
-      const top = i / this.width || 0;
+      const top = i / this.width | 0;
       let right = left + 1;
       let bottom = top + 1;
 

--- a/src/tableview.ts
+++ b/src/tableview.ts
@@ -25,8 +25,8 @@ export class TableView implements NodeView {
   update(node: ProsemirrorNode): boolean {
     if (node.type != this.node.type) return false;
     this.node = node;
-    const pos = this.getPos();
     updateColumnsOnResize(node, this.contentDOM, this.cellMinWidth);
+    // const pos = this.getPos();
     // if (pos) console.log(getTableWidths(node, pos + 1, this.cellMinWidth));
     return true;
   }

--- a/src/tableview.ts
+++ b/src/tableview.ts
@@ -1,0 +1,129 @@
+import { Node as ProsemirrorNode } from 'prosemirror-model';
+import { EditorView, NodeView } from 'prosemirror-view';
+import { CellAttrs, getRow } from './util';
+
+/**
+ * @public
+ */
+export class TableView implements NodeView {
+  public dom: HTMLDivElement;
+  public contentDOM: HTMLTableElement;
+
+  constructor(
+    public node: ProsemirrorNode,
+    public cellMinWidth: number,
+    public view: EditorView,
+    public getPos: () => number | undefined,
+  ) {
+    this.dom = document.createElement('div');
+    this.dom.className = 'tableWrapper';
+    this.contentDOM = this.dom.appendChild(document.createElement('table'));
+    const pos = getPos();
+    updateColumnsOnResize(node, this.contentDOM, cellMinWidth);
+  }
+
+  update(node: ProsemirrorNode): boolean {
+    if (node.type != this.node.type) return false;
+    this.node = node;
+    const pos = this.getPos();
+    updateColumnsOnResize(node, this.contentDOM, this.cellMinWidth);
+    // if (pos) console.log(getTableWidths(node, pos + 1, this.cellMinWidth));
+    return true;
+  }
+
+  ignoreMutation(record: MutationRecord): boolean {
+    const table = this.contentDOM
+    const colgroup = getColgroup(table)
+    return (
+      record.type == 'attributes' &&
+      (record.target == table || (colgroup && colgroup.contains(record.target)))
+    );
+  }
+}
+
+function getColgroup(table: HTMLTableElement): HTMLElement {
+  let colgroup = table.firstChild as HTMLElement;
+  let childIndex = 0;
+  while (colgroup) {
+    const nodeName = colgroup.nodeName
+    if (nodeName === 'COLGROUP') {
+      break
+    } else if (nodeName==='CAPTION'){
+      colgroup = colgroup.nextSibling as HTMLElement;
+      childIndex++;
+    } else {
+      break
+    }
+  }
+  if (colgroup) {
+    if (colgroup.nodeName === 'COLGROUP') {
+    } else {
+      colgroup = table.insertBefore(
+        document.createElement('COLGROUP'),
+        table.children[childIndex],
+      );
+    }
+  } else {
+    if (table.children.length === 0) {
+      colgroup = table.appendChild(document.createElement('COLGROUP'));
+    } else {
+      colgroup = table.insertBefore(
+        document.createElement('COLGROUP'),
+        table.children[0],
+      );
+    }
+  }
+  return colgroup;
+}
+
+/**
+ * @public
+ */
+export function updateColumnsOnResize(
+  node: ProsemirrorNode,
+  table: HTMLTableElement,
+  cellMinWidth: number,
+  overrideCol?: number,
+  overrideValue?: number,
+): void {
+  let totalWidth = 0;
+  let fixedWidth = true;
+  const colgroup = getColgroup(table)
+  if (!colgroup) return;
+
+  let nextDOM = colgroup.firstChild as HTMLElement;
+  const row = getRow(node, 0).node;
+  if (!row) return;
+
+  for (let i = 0, col = 0; i < row.childCount; i++) {
+    const { colspan, colwidth } = row.child(i).attrs as CellAttrs;
+    for (let j = 0; j < colspan; j++, col++) {
+      const hasWidth =
+        overrideCol == col ? overrideValue : colwidth && colwidth[j];
+      const cssWidth = hasWidth ? hasWidth + 'px' : '';
+      totalWidth += hasWidth || cellMinWidth;
+      if (!hasWidth) fixedWidth = false;
+      if (!nextDOM) {
+        colgroup.appendChild(document.createElement('col')).style.width =
+          cssWidth;
+      } else {
+        if (nextDOM.style.width != cssWidth) nextDOM.style.width = cssWidth;
+        nextDOM = nextDOM.nextSibling as HTMLElement;
+      }
+    }
+  }
+
+  while (nextDOM) {
+    const after = nextDOM.nextSibling;
+    nextDOM.parentNode?.removeChild(nextDOM);
+    nextDOM = after as HTMLElement;
+  }
+
+  if (fixedWidth) {
+    table.style.width = totalWidth + 'px';
+    table.style.minWidth = '';
+  } else {
+    table.style.width = '';
+    table.style.minWidth = totalWidth + 'px';
+  }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,11 @@
 // Various helper function for working with tables
 
-import { EditorState, NodeSelection, PluginKey } from 'prosemirror-state';
+import {
+  EditorState,
+  NodeSelection,
+  PluginKey,
+  Selection,
+} from 'prosemirror-state';
 import { Attrs, Node, ResolvedPos } from 'prosemirror-model';
 import { CellSelection } from './cellselection';
 import { isTableSection, tableNodeTypes } from './schema';
@@ -42,25 +47,6 @@ export function cellWrapping($pos: ResolvedPos): null | Node {
     if (role === 'cell' || role === 'header_cell') return $pos.node(d);
   }
   return null;
-}
-
-/**
- * @public
- */
-export function isInTable(state: EditorState): boolean {
-  const $head = state.selection.$head;
-  for (let d = $head.depth; d > 0; d--)
-    if ($head.node(d).type.spec.tableRole == 'row') return true;
-  return false;
-}
-
-/**
- * @internal
- */
-export function tableDepth($pos: ResolvedPos): number {
-  for (let d = $pos.depth; d >= 0; d--)
-    if ($pos.node(d).type.spec.tableRole == 'table') return d;
-  return -1;
 }
 
 /**
@@ -354,4 +340,30 @@ export function isRowLastInSection(table: Node, row: number): boolean {
     if (row < rowsMinusOne) return false;
   }
   return false;
+}
+
+/**
+ * @public
+ */
+export function isInTable(state: EditorState): boolean {
+  const $head = state.selection.$head;
+  for (let d = $head.depth; d > 0; d--)
+    if ($head.node(d).type.spec.tableRole == 'row') return true;
+  return false;
+}
+
+/**
+ * @internal
+ */
+export function tableDepth($pos: ResolvedPos): number {
+  for (let d = $pos.depth; d >= 0; d--)
+    if ($pos.node(d).type.spec.tableRole == 'table') return d;
+  return -1;
+}
+
+export function innerTableInSelection(selection: Selection): Node | undefined {
+  const depth = tableDepth(selection.$head);
+  if (depth >= 0) {
+    return selection.$head.node(depth);
+  }
 }

--- a/test/column-resizing.test.ts
+++ b/test/column-resizing.test.ts
@@ -3,6 +3,7 @@ import { EditorState } from 'prosemirror-state';
 import { handleDecorations } from '../src/columnresizing';
 import { table, doc, tr, cEmpty, tbody } from './build';
 import { describe, it } from 'vitest';
+import { DecorationSet } from 'prosemirror-view';
 
 describe('handleDecorations', () => {
   it('returns an empty array (Decoration[]) if cell is null or undefined', () => {
@@ -10,7 +11,7 @@ describe('handleDecorations', () => {
       doc: doc(table(tbody(tr(/* 2*/ cEmpty, /* 6*/ cEmpty, /*10*/ cEmpty)))),
     });
     // @ts-expect-error: null is not a valid number
-    const decos = handleDecorations(state, null);
-    ist(decos instanceof Array && decos.length === 0);
+    const decoSet = handleDecorations(state, null);
+    ist(decoSet instanceof DecorationSet && decoSet.find(undefined, undefined, () => true).length === 0)
   });
 });


### PR DESCRIPTION
**Previous problem**: using Tab to navigate to a cell would select the whole cell. When you then typed, I think the whole cell would be deleted and remade. This caused header cells to turn into body cells, when really the intention of the user was to replace the *contents* of the cell.

**New solution**: Tab should select the *first child* of the next cell, rather than the cell itself.

**Bonus change**: merged in changes from upstream for some additional fixes